### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/avahi-python/avahi/__init__.py
+++ b/avahi-python/avahi/__init__.py
@@ -107,6 +107,6 @@ def dict_to_txt_array(txt_dict):
     l = []
 
     for k,v in txt_dict.items():
-        l.append(string_to_byte_array("%s=%s" % (k,v)))
+        l.append(string_to_byte_array("{0!s}={1!s}".format(k, v)))
 
     return l

--- a/tests/c-plus-plus-test-gen.py
+++ b/tests/c-plus-plus-test-gen.py
@@ -21,12 +21,12 @@ import os, sys
 
 def print_includes(dir):
 
-    files = os.listdir("../%s" % dir)
+    files = os.listdir("../{0!s}".format(dir))
     files = filter(lambda fn: fn.endswith(".h") and not fn.startswith("."), files)
     files.sort()
 
     for f in files:
-        print "#include <%s/%s>" % (dir, f)
+        print "#include <{0!s}/{1!s}>".format(dir, f)
 
 
 print """/***


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:avahi?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:avahi?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
